### PR TITLE
addWatch: don't cancel other watches

### DIFF
--- a/src/System/INotify.hsc
+++ b/src/System/INotify.hsc
@@ -200,7 +200,7 @@ addWatch inotify@(INotify _ fd em _ _) masks fp cb = do
     wd <- withCString enc fp $ \fp_c ->
             throwErrnoIfMinus1 "addWatch" $
               c_inotify_add_watch (fromIntegral fd) fp_c mask
-    let event = \e -> do
+    let event = \e -> ignore_failure $ do
             case e of
               -- if the event is Ignored then we know for sure that
               -- this is the last event on that WatchDescriptor
@@ -234,6 +234,12 @@ addWatch inotify@(INotify _ fd em _ _) masks fp cb = do
             MaskAdd -> inMaskAdd
             OneShot -> inOneshot
             AllEvents -> inAllEvents
+
+    ignore_failure :: IO () -> IO ()
+    ignore_failure action = mask_ (action `E.catch` ignore)
+      where
+      ignore :: SomeException -> IO ()
+      ignore _ = return ()
 
 removeWatch :: WatchDescriptor -> IO ()
 removeWatch (WatchDescriptor (INotify _ fd _ _ _) wd) = do
@@ -312,19 +318,13 @@ inotify_start_thread h em = do
     runHandler :: WDEvent -> IO ()
     runHandler (_,  e@QOverflow) = do -- send overflows to all handlers
         handlers <- readMVar em
-        flip mapM_ (Map.elems handlers) $ \handler ->
-            ignore_failure (handler e) -- supress errors
+        mapM_ ($ e) (Map.elems handlers)
     runHandler (wd, event) = do 
         handlers <- readMVar em
         let handlerM = Map.lookup wd handlers
         case handlerM of
           Nothing -> putStrLn "runHandler: couldn't find handler" -- impossible?
-          Just handler -> ignore_failure (handler event)
-    ignore_failure :: IO () -> IO ()
-    ignore_failure action = mask_ (action `E.catch` ignore)
-      where
-      ignore :: SomeException -> IO ()
-      ignore _ = return ()
+          Just handler -> handler event
 
 killINotify :: INotify -> IO ()
 killINotify (INotify h _ _ tid1 tid2) =


### PR DESCRIPTION
Previously, addWatch would override any actions already registered with the
same watch descriptor (i.e. related to the same path). This commit changes the
behaviour so that the previously registered actions are kept.

Here's the test I used for this:

```
import Control.Concurrent
import Control.Exception
import Control.Applicative
import System.INotify

main = do
  ino <- initINotify
  let foo = "foo"
  writeFile foo "blah"

  _ <- addWatch ino [Open] foo $ \e -> putStrLn "opened"
  evaluate =<< length <$> readFile foo
  threadDelay (10^6)

  _ <- addWatch ino [Access] foo $ \e -> putStrLn "accessed"
  evaluate =<< length <$> readFile foo
  threadDelay (10^6)
```

It's in a different style than the project's tests (it registers the actions rather than just gathering the events), so I didn't include it, but feel free to adapt it for the test suite.
