### PR TITLE
Fix problems with callbacks and killINotify

### DIFF
--- a/hinotify.cabal
+++ b/hinotify.cabal
@@ -13,15 +13,16 @@ license-file:       LICENSE
 author:             Lennart Kolmodin
 maintainer:         Lennart Kolmodin <kolmodin@gmail.com>
 extra-source-files: README.md, CHANGELOG.md
-cabal-version:      >= 1.8
+cabal-version:      >= 1.10
 
 source-repository head
   type: git
   location: git://github.com/kolmodin/hinotify.git
 
 library
-    build-depends:  base >= 4.5.0.0 && < 5, containers, directory, unix
-    extensions:     ForeignFunctionInterface
+    default-language: Haskell2010
+    build-depends:  base >= 4.5.0.0 && < 5, containers, directory, unix,
+                    async >= 1.0 && < 2.2
 
     exposed-modules:
         System.INotify
@@ -34,6 +35,7 @@ library
 
 test-suite test001
     type: exitcode-stdio-1.0
+    default-language: Haskell2010
     build-depends: base, directory, hinotify
     hs-source-dirs: src tests
     main-is: test001-list-dir-contents.hs
@@ -42,6 +44,7 @@ test-suite test001
 
 test-suite test002
     type: exitcode-stdio-1.0
+    default-language: Haskell2010
     build-depends: base, directory, hinotify
     hs-source-dirs: src tests
     main-is: test002-writefile.hs
@@ -50,6 +53,7 @@ test-suite test002
 
 test-suite test003
     type: exitcode-stdio-1.0
+    default-language: Haskell2010
     build-depends: base, directory, hinotify
     hs-source-dirs: src tests
     main-is: test003-removefile.hs
@@ -58,6 +62,7 @@ test-suite test003
 
 test-suite test004
     type: exitcode-stdio-1.0
+    default-language: Haskell2010
     build-depends: base, directory, hinotify
     hs-source-dirs: src tests
     main-is: test004-modify-file.hs
@@ -67,7 +72,17 @@ test-suite test004
 test-suite test005
     type: exitcode-stdio-1.0
     build-depends: base, directory, hinotify
+    default-language: Haskell2010
     hs-source-dirs: src tests
     main-is: test005-move-file.hs
+    other-modules: Utils
+    ghc-options: -Wall
+
+test-suite test006
+    type: exitcode-stdio-1.0
+    build-depends: base, directory, hinotify
+    default-language: Haskell2010
+    hs-source-dirs: src tests
+    main-is: test006-callbackHang.hs
     other-modules: Utils
     ghc-options: -Wall

--- a/tests/test006-callbackHang.hs
+++ b/tests/test006-callbackHang.hs
@@ -1,0 +1,31 @@
+module Main where
+
+import Control.Concurrent
+
+import System.INotify as INotify
+import System.Timeout
+
+import Utils
+
+file :: String
+file = "hello"
+
+write :: String -> IO ()
+write path = do
+    writeFile (path ++ '/':file) ""
+
+main :: IO ()
+main = maybe testFailure (const testSuccess) =<< timeout 1000000 doTest
+
+doTest :: IO ()
+doTest =
+    withTempDir $ \testPath -> do
+        inot <- initINotify
+        mvar1 <- newEmptyMVar
+        mvar2 <- newEmptyMVar
+        _ <- addWatch inot [AllEvents] testPath $ \_event -> do
+            putMVar mvar1 ()
+            takeMVar mvar2 -- hangs here
+        write testPath
+        takeMVar mvar1
+        killINotify inot -- should complete and kill all threads

--- a/tests/test006-callbackHang.hs
+++ b/tests/test006-callbackHang.hs
@@ -32,4 +32,3 @@ doTest =
                 takeMVar mvar2 -- hangs here
             write testPath
             takeMVar mvar1
-            killINotify inot


### PR DESCRIPTION
1. We shouldn't run the callback inside mask_, because that prevents it
   from receiving StackOverflow, amongst other things.  I think this was
   a  n attempt to prevent the delivery of ThreadKilled inside the
   callback, but to do that you would need uninterruptibleMask_

2. killThread doesn't wait for the threads to die, so use the async
   package and cancel/wait instead.

3. If the killThread happens during a callback, we don't want to discard
   the exception, because that will leave the thread running.

I've added a new test for the problem of a callback hanging.