### PR TITLE
CABAL: 'directory' is not needed for the library

### DIFF
--- a/hinotify.cabal
+++ b/hinotify.cabal
@@ -21,7 +21,7 @@ source-repository head
 
 library
     default-language: Haskell2010
-    build-depends:  base >= 4.5.0.0 && < 5, bytestring, containers, directory, unix,
+    build-depends:  base >= 4.5.0.0 && < 5, bytestring, containers, unix,
                     async >= 1.0 && < 2.2
 
     exposed-modules:


### PR DESCRIPTION
Only for the test suite (and the examples).