### PR TITLE
Allow async-2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.2
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.2.1
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.1], sources: [hvr-ghc]}}
+    - env: CABALVER=2.2 GHCVER=8.4.1
+      addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.1], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
       addons: {apt: {packages: [cabal-install-head,ghc-head],  sources: [hvr-ghc]}}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 hinotify
 ======
 
+hinotify-0.3.10
+---------------
+
+- Allow async-2.2
+
 hinotify-0.3.9
 --------------
 

--- a/hinotify.cabal
+++ b/hinotify.cabal
@@ -22,7 +22,7 @@ source-repository head
 library
     default-language: Haskell2010
     build-depends:  base >= 4.5.0.0 && < 5, bytestring, containers, unix,
-                    async >= 1.0 && < 2.2
+                    async >= 1.0 && < 2.3
 
     exposed-modules:
         System.INotify


### PR DESCRIPTION
Enables the inclusion back on stackage, which is required to get fsnotify and ghcid back on Stackage.