### PR TITLE
Tighten lower bound on async

### DIFF
--- a/hinotify.cabal
+++ b/hinotify.cabal
@@ -22,7 +22,7 @@ source-repository head
 library
     default-language: Haskell2010
     build-depends:  base >= 4.5.0.0 && < 5, bytestring, containers, unix,
-                    async >= 1.0 && < 2.3
+                    async >= 2.0 && < 2.3
 
     exposed-modules:
         System.INotify


### PR DESCRIPTION
This package uses `import Control.Concurrent.Async`, which wasn't exported by the `async` package until version `2.0`

As a hackage trustee, I've made this revision on versions 0.3.9 and 0.3.10 of `hinotify` on hackage.