### PR TITLE
Depend on inotify library on {Free,Open}BSD

### DIFF
--- a/hinotify.cabal
+++ b/hinotify.cabal
@@ -34,6 +34,9 @@ library
     includes: sys/inotify.h
     hs-source-dirs: src
 
+    if os(freebsd) || os(openbsd)
+      extra-libraries: inotify
+
 test-suite test001
     type: exitcode-stdio-1.0
     default-language: Haskell2010


### PR DESCRIPTION
FreeBSD carries this as a local patch:
https://github.com/freebsd/freebsd-ports/blob/master/x11/hs-xmobar/files/extra-patch-hinotify.cabal#L7