### PR TITLE
Fix Event names in haddock

### DIFF
--- a/src/System/INotify.hsc
+++ b/src/System/INotify.hsc
@@ -102,13 +102,13 @@ data Event =
         { isDirectory :: Bool
         , maybeFilePath :: Maybe RawFilePath
         }
-    -- | A file was moved away from the watched dir. @MovedFrom isDirectory from cookie@
+    -- | A file was moved away from the watched dir. @MovedOut isDirectory from cookie@
     | MovedOut
         { isDirectory :: Bool
         , filePath :: RawFilePath
         , moveCookie :: Cookie
         }
-    -- | A file was moved into the watched dir. @MovedTo isDirectory to cookie@
+    -- | A file was moved into the watched dir. @MovedIn isDirectory to cookie@
     | MovedIn
         { isDirectory :: Bool
         , filePath :: RawFilePath


### PR DESCRIPTION
This is slightly confusing, because events are named somewhat differently then their corresponding masks.